### PR TITLE
Fix/Define sl and tp in GUI

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -609,6 +609,8 @@ class TradingPage(ttk.Frame):
                        strategy_comment: str):
         """Runs on the Tk mainloop—safe to update UI."""
         price_str = f"{price:.5f}" if price is not None else "N/A (unknown)"
+        sl = sl_pips_gui
+        tp = tp_pips_gui
         self._log(f"{side.upper()} scalp: {symbol} at {price_str} | "
                   f"size={size} lots | SL={sl} pips | TP={tp} pips")
 


### PR DESCRIPTION
This commit fixes a bug where the `sl` and `tp` variables were not defined in the `_execute_trade` method in `gui.py`. This was causing a `NameError` when trying to place a trade.

The fix defines the `sl` and `tp` variables before they are used, setting them to the values from the GUI.